### PR TITLE
Domex neutron raytracing

### DIFF
--- a/EXT_NRAYTRACING.md
+++ b/EXT_NRAYTRACING.md
@@ -11,39 +11,102 @@ This extention is designed for transfer of neutron particle states between neutr
 The neutrons are saved in rays with a given weight corresponding to expected intensity.
 This standard is not yet finished and is currently based on EXT_BeamPhysics / EXT_WAVEFRONT
 
+Each record needs to have the same length, as the n'th index for each record correspond to particle n.
+
 Particle Records
 ----------------
 
 - `position/`
-    - type: Required 3-vector *(real)*
-    - components: (`x`, `y`, `z`)
+    - type: Required
     - description: particle Position relative to the `positionOffset`.
     That is, true position relative to the coordinate origin = `position + positionOffset`.
+    - `position/x` 
+        - type: Required *(real)*
+        - description: x coordinate
+        - unitDimension: [m] (1., 0., 0., 0., 0., 0., 0.)
+        - unitSI: 1.0      
+    - `position/y` 
+        - type: Required *(real)*
+        - description: y coordinate
+        - unitDimension: [m] (1., 0., 0., 0., 0., 0., 0.)        
+        - unitSI: 1.0      
+    - `position/z` 
+        - type: Required *(real)*
+        - description: z coordinate
+        - unitDimension: [m] (1., 0., 0., 0., 0., 0., 0.)        
+        - unitSI: 1.0
 
 - `positionOffset/`
-    - type: Optional 3-vector *(real)*
-    - description: Offset for each particle position component relative to the coordinate origin. Assumed zero if not present.
-    - components: (`x`, `y`, `z`)
+    - type: Optional
+    - description: Offset for each particle position component relative to the coordinate origin. Assumed zero if not present. If only one present, assumed the same for each particle.
+    - `position/x` 
+        - type: Optional *(real)*
+        - description: x coordinate offset
+        - unitDimension: [m] (1., 0., 0., 0., 0., 0., 0.)
+        - unitSI: 1.0      
+    - `position/y` 
+        - type: Optional *(real)*
+        - description: y coordinate offset
+        - unitDimension: [m] (1., 0., 0., 0., 0., 0., 0.)        
+        - unitSI: 1.0      
+    - `position/z` 
+        - type: Optional *(real)*
+        - description: z coordinate offset
+        - unitDimension: [m] (1., 0., 0., 0., 0., 0., 0.)   
+        - unitSI: 1.0      
+    
+- `velocity/`
+    - type: Required
+    - description: (`x`, `y`, `z`) velocity vector. Used over momentum due to direct relevance for ray-tracing.
+    - `velocity/x` 
+        - type: Required *(real)*
+        - description: x velocity
+        - unitDimension: [m/s] (1., 0., -1.0, 0., 0., 0., 0.)
+        - unitSI: 1.0      
+    - `velocity/y` 
+        - type: Required *(real)*
+        - description: y velocity
+        - unitDimension: [m/s] (1., 0., -1.0, 0., 0., 0., 0.)    
+        - unitSI: 1.0      
+    - `velocity/z` 
+        - type: Required *(real)*
+        - description: z velocity
+        - unitDimension: [m/s] (1., 0., -1.0, 0., 0., 0., 0.)
+        - unitSI: 1.0
     
 - `spin/`
-    - type: Optional 3-vector *(real)*
-    - description: Particle spin.
-    - components: (`x`, `y`, `z`) or (`r`, `theta`, `phi`).
+    - type: Optional 
+    - description: Particle spin direction, no unit
+    - `spin/x` 
+        - type: Optional *(real)*
+        - description: x component of spin
+        - unitDimension: [unitless] (0., 0., 0., 0., 0., 0., 0.)
+        - unitSI: 1.0
+    - `spin/y` 
+        - type: Optional *(real)*
+        - description: y component of spin
+        - unitDimension: [unitless] (0., 0., 0., 0., 0., 0., 0.)
+        - unitSI: 1.0
+    - `spin/z` 
+        - type: Optional *(real)*
+        - description: z component of spin
+        - unitDimension: [unitless] (0., 0., 0., 0., 0., 0., 0.)
+        - unitSI: 1.0        
     
 - `time/`
-    - type: Optional *(real)*
+    - type: Required *(real)*
     - description: Time relative to `timeOffset`. That is, absolute time = `time + timeOffset`.
+    - unitDimension: [unitless] (0., 0., 0., 1., 0., 0., 0., 0.)
+    - unitSI: 1.0        
     
 - `timeOffset/`
     - type: Optional *(real)*
     - description: Base time from which `time` is measured. That is, absolute time = `time + timeOffset`. Assumed zero if not present. Some programs will use the `timeOffset` to store the **reference time** in which case `time` will then be the deviation from the reference.
-
-- `velocity/`
-  - type: Required 3-vector *(real)*
-  - description: (`x`, `y`, `z`) velocity vector. Meant to be used for photons where using `momentum` is not appropriate.
+    - unitDimension: [unitless] (0., 0., 0., 1., 0., 0., 0., 0.)
+    - unitSI: 1.0            
 
 - `weight/`
     - type: Required *(real)*
     - description: Weight of the neutron ray with the physical unit of intensity, neutrons per second. When simulating a source with a given intensity, this intensity is split up into weights of the neutron rays that will be simulated.
-    
-    
+    - unitDimension: [unitless] (0., 0., 0., 1., 0., 0., 0., 0.)
+    - unitSI: 1.0

--- a/EXT_NRAYTRACING.md
+++ b/EXT_NRAYTRACING.md
@@ -22,17 +22,17 @@ Particle Records
     - type: Required
     - description: particle Position relative to the `positionOffset`.
     That is, true position relative to the coordinate origin = `position + positionOffset`.
-    - `position/x` 
+    - `x` 
         - type: Required *(real)*
         - description: x coordinate
         - unitDimension: [m] (1., 0., 0., 0., 0., 0., 0.)
         - unitSI: 1.0      
-    - `position/y` 
+    - `y` 
         - type: Required *(real)*
         - description: y coordinate
         - unitDimension: [m] (1., 0., 0., 0., 0., 0., 0.)        
         - unitSI: 1.0      
-    - `position/z` 
+    - `z` 
         - type: Required *(real)*
         - description: z coordinate
         - unitDimension: [m] (1., 0., 0., 0., 0., 0., 0.)        
@@ -41,17 +41,17 @@ Particle Records
 - `positionOffset/`
     - type: Optional
     - description: Offset for each particle position component relative to the coordinate origin. Assumed zero if not present. If only one present, assumed the same for each particle.
-    - `position/x` 
+    - `x` 
         - type: Optional *(real)*
         - description: x coordinate offset
         - unitDimension: [m] (1., 0., 0., 0., 0., 0., 0.)
         - unitSI: 1.0      
-    - `position/y` 
+    - `y` 
         - type: Optional *(real)*
         - description: y coordinate offset
         - unitDimension: [m] (1., 0., 0., 0., 0., 0., 0.)        
         - unitSI: 1.0      
-    - `position/z` 
+    - `z` 
         - type: Optional *(real)*
         - description: z coordinate offset
         - unitDimension: [m] (1., 0., 0., 0., 0., 0., 0.)   
@@ -60,17 +60,17 @@ Particle Records
 - `velocity/`
     - type: Required
     - description: (`x`, `y`, `z`) velocity vector. Used over momentum due to direct relevance for ray-tracing.
-    - `velocity/x` 
+    - `x` 
         - type: Required *(real)*
         - description: x velocity
         - unitDimension: [m/s] (1., 0., -1.0, 0., 0., 0., 0.)
         - unitSI: 1.0      
-    - `velocity/y` 
+    - `y` 
         - type: Required *(real)*
         - description: y velocity
         - unitDimension: [m/s] (1., 0., -1.0, 0., 0., 0., 0.)    
         - unitSI: 1.0      
-    - `velocity/z` 
+    - `z` 
         - type: Required *(real)*
         - description: z velocity
         - unitDimension: [m/s] (1., 0., -1.0, 0., 0., 0., 0.)
@@ -79,17 +79,17 @@ Particle Records
 - `spin/`
     - type: Optional 
     - description: Particle spin direction, no unit
-    - `spin/x` 
+    - `x` 
         - type: Optional *(real)*
         - description: x component of spin
         - unitDimension: [unitless] (0., 0., 0., 0., 0., 0., 0.)
         - unitSI: 1.0
-    - `spin/y` 
+    - `y` 
         - type: Optional *(real)*
         - description: y component of spin
         - unitDimension: [unitless] (0., 0., 0., 0., 0., 0., 0.)
         - unitSI: 1.0
-    - `spin/z` 
+    - `z` 
         - type: Optional *(real)*
         - description: z component of spin
         - unitDimension: [unitless] (0., 0., 0., 0., 0., 0., 0.)

--- a/EXT_NRAYTRACING.md
+++ b/EXT_NRAYTRACING.md
@@ -7,11 +7,14 @@ openPMD extension name: `NRAYTRACING`
 Introduction
 ------------
 
-This extention is designed for transfer of neutron particle states between neutron raytracing simulation codes.
-The neutrons are saved in rays with a given weight corresponding to expected intensity.
-This standard is not yet finished and is currently based on EXT_BeamPhysics / EXT_WAVEFRONT
+This extention is designed for neutron raytracing data that can be transfered between neutron raytracing simulation codes.
+The neutrons are saved in rays with a given weight corresponding to expected intensity of the ray.
 
-Each record needs to have the same length, as the n'th index for each record correspond to particle n.
+For most records, the information is stored per neutron and so they must have the same length, which is the case for position, velocity, polarization, weight and time. The largest deviation from the base openPMD standard is that neutron raytracing packages keeps independent time for each particle, as they are non-interacting.
+
+If positionOffset only contain a single set of coordinates, it is assumed to be constant for all neutrons, but it is allowed to have individual for each ray, in which case the length should match the remaining vectors. timeOffset however is only allowed to be a scalar, as no situations with independent timeOffset for each neutron is foreseen.
+
+The neutron polarization is optional as it is only relevant for a minority of experiments/simulations. The positionOffset and timeOffset are optional as a value of zero for both is 
 
 Coordinates are defined with z in the beam direction and if possible y in the direction opposite gravity.
 
@@ -21,7 +24,7 @@ Particle Records
 - `position/`
     - type: Required
     - description: particle Position relative to the `positionOffset`.
-    That is, true position relative to the coordinate origin = `position + positionOffset`.
+    That is, true position relative to the coordinate origin is `position + positionOffset`.
     - `x` 
         - type: Required *(real)*
         - description: x coordinate
@@ -78,37 +81,39 @@ Particle Records
     
 - `spin/`
     - type: Optional 
-    - description: Particle polarisation direction, no unit
+    - description: Particle polarisation direction, no unit. The entire record is optional, but if it is given all components are required.
     - `x` 
-        - type: Optional *(real)*
+        - type: Required *(real)*
         - description: x component of polarisation
         - unitDimension: [unitless] (0., 0., 0., 0., 0., 0., 0.)
         - unitSI: 1.0
     - `y` 
-        - type: Optional *(real)*
+        - type: Required *(real)*
         - description: y component of polarisation
         - unitDimension: [unitless] (0., 0., 0., 0., 0., 0., 0.)
         - unitSI: 1.0
     - `z` 
-        - type: Optional *(real)*
+        - type: Required *(real)*
         - description: z component of polarisation
         - unitDimension: [unitless] (0., 0., 0., 0., 0., 0., 0.)
         - unitSI: 1.0        
     
-- `time/`
-    - type: Required *(real)*
-    - description: Time relative to `timeOffset`. That is, absolute time = `time + timeOffset`.
-    - unitDimension: [s] (0., 0., 1., 0., 0., 0., 0.)
-    - unitSI: 1.0        
-    
-- `timeOffset/`
-    - type: Optional *(real)*
-    - description: Base time from which `time` is measured. That is, absolute time = `time + timeOffset`. Assumed zero if not present. Some programs will use the `timeOffset` to store the **reference time** in which case `time` will then be the deviation from the reference.
-    - unitDimension: [s] (0., 0., 1., 0., 0., 0., 0.)
-    - unitSI: 1.0            
-
 - `weight/`
     - type: Required *(real)*
     - description: Weight of the neutron ray with the physical unit of intensity, neutrons per second. When simulating a source with a given intensity, this intensity is split up into weights of the neutron rays that will be simulated.
     - unitDimension: [neutrons/s] (0., 0., 0., 0., 0., 0., 0.)
     - unitSI: 1.0
+
+- `time/`
+    - type: Required *(real)*
+    - description: Time relative to `timeOffset`. That is, absolute time = `time + timeOffset`.
+    - unitDimension: [s] (0., 0., 1., 0., 0., 0., 0.)
+    - unitSI: 1.0
+    
+- `timeOffset/`
+    - type: Optional *(real)*
+    - description: Base time from which `time` is measured. That is, absolute time = `time + timeOffset`. Assumed zero if not present. Some programs will use the `timeOffset` to store the **reference time** in which case `time` will then be the deviation from the reference.
+    - unitDimension: [s] (0., 0., 1., 0., 0., 0., 0.)
+    - unitSI: 1.0
+
+

--- a/EXT_NRAYTRACING.md
+++ b/EXT_NRAYTRACING.md
@@ -13,6 +13,8 @@ This standard is not yet finished and is currently based on EXT_BeamPhysics / EX
 
 Each record needs to have the same length, as the n'th index for each record correspond to particle n.
 
+Coordinates are defined with z in the beam direction and if possible y in the direction opposite gravity.
+
 Particle Records
 ----------------
 

--- a/EXT_NRAYTRACING.md
+++ b/EXT_NRAYTRACING.md
@@ -78,20 +78,20 @@ Particle Records
     
 - `spin/`
     - type: Optional 
-    - description: Particle spin direction, no unit
+    - description: Particle polarisation direction, no unit
     - `x` 
         - type: Optional *(real)*
-        - description: x component of spin
+        - description: x component of polarisation
         - unitDimension: [unitless] (0., 0., 0., 0., 0., 0., 0.)
         - unitSI: 1.0
     - `y` 
         - type: Optional *(real)*
-        - description: y component of spin
+        - description: y component of polarisation
         - unitDimension: [unitless] (0., 0., 0., 0., 0., 0., 0.)
         - unitSI: 1.0
     - `z` 
         - type: Optional *(real)*
-        - description: z component of spin
+        - description: z component of polarisation
         - unitDimension: [unitless] (0., 0., 0., 0., 0., 0., 0.)
         - unitSI: 1.0        
     
@@ -110,5 +110,5 @@ Particle Records
 - `weight/`
     - type: Required *(real)*
     - description: Weight of the neutron ray with the physical unit of intensity, neutrons per second. When simulating a source with a given intensity, this intensity is split up into weights of the neutron rays that will be simulated.
-    - unitDimension: [unitless] (0., 0., 0., 0., 0., 0., 0.)
+    - unitDimension: [neutrons/s] (0., 0., 0., 0., 0., 0., 0.)
     - unitSI: 1.0

--- a/EXT_NRAYTRACING.md
+++ b/EXT_NRAYTRACING.md
@@ -1,0 +1,49 @@
+Domain-Specific Naming Conventions for Neutron raytracing codes
+===============================================================
+
+openPMD extension name: `NRAYTRACING`
+
+
+Introduction
+------------
+
+This extention is designed for transfer of neutron particle states between neutron raytracing simulation codes.
+The neutrons are saved in rays with a given weight corresponding to expected intensity.
+This standard is not yet finished and is currently based on EXT_BeamPhysics / EXT_WAVEFRONT
+
+Particle Records
+----------------
+
+- `position/`
+    - type: Required 3-vector *(real)*
+    - components: (`x`, `y`, `z`)
+    - description: particle Position relative to the `positionOffset`.
+    That is, true position relative to the coordinate origin = `position + positionOffset`.
+
+- `positionOffset/`
+    - type: Optional 3-vector *(real)*
+    - description: Offset for each particle position component relative to the coordinate origin. Assumed zero if not present.
+    - components: (`x`, `y`, `z`)
+    
+- `spin/`
+    - type: Optional 3-vector *(real)*
+    - description: Particle spin.
+    - components: (`x`, `y`, `z`) or (`r`, `theta`, `phi`).
+    
+- `time/`
+    - type: Optional *(real)*
+    - description: Time relative to `timeOffset`. That is, absolute time = `time + timeOffset`.
+    
+- `timeOffset/`
+    - type: Optional *(real)*
+    - description: Base time from which `time` is measured. That is, absolute time = `time + timeOffset`. Assumed zero if not present. Some programs will use the `timeOffset` to store the **reference time** in which case `time` will then be the deviation from the reference.
+
+- `velocity/`
+  - type: Required 3-vector *(real)*
+  - description: (`x`, `y`, `z`) velocity vector. Meant to be used for photons where using `momentum` is not appropriate.
+
+- `weight/`
+    - type: Required *(real)*
+    - description: Weight of the neutron ray with the physical unit of intensity, neutrons per second. When simulating a source with a given intensity, this intensity is split up into weights of the neutron rays that will be simulated.
+    
+    

--- a/EXT_NRAYTRACING.md
+++ b/EXT_NRAYTRACING.md
@@ -98,17 +98,17 @@ Particle Records
 - `time/`
     - type: Required *(real)*
     - description: Time relative to `timeOffset`. That is, absolute time = `time + timeOffset`.
-    - unitDimension: [unitless] (0., 0., 0., 1., 0., 0., 0., 0.)
+    - unitDimension: [s] (0., 0., 1., 0., 0., 0., 0.)
     - unitSI: 1.0        
     
 - `timeOffset/`
     - type: Optional *(real)*
     - description: Base time from which `time` is measured. That is, absolute time = `time + timeOffset`. Assumed zero if not present. Some programs will use the `timeOffset` to store the **reference time** in which case `time` will then be the deviation from the reference.
-    - unitDimension: [unitless] (0., 0., 0., 1., 0., 0., 0., 0.)
+    - unitDimension: [s] (0., 0., 1., 0., 0., 0., 0.)
     - unitSI: 1.0            
 
 - `weight/`
     - type: Required *(real)*
     - description: Weight of the neutron ray with the physical unit of intensity, neutrons per second. When simulating a source with a given intensity, this intensity is split up into weights of the neutron rays that will be simulated.
-    - unitDimension: [unitless] (0., 0., 0., 1., 0., 0., 0., 0.)
+    - unitDimension: [unitless] (0., 0., 0., 0., 0., 0., 0.)
     - unitSI: 1.0


### PR DESCRIPTION
openPMD extension for neutron ray tracing simulations. https://github.com/PaNOSC-ViNYL/ViNYL-project/issues/15

*Implements issue:* #15 

## Description
Small extension to openPMD for neutron raytracing with the purpose of transferring neutron states between raytracing simulation packages.

Each neutron is described with an independent state with the following parameters:
- position (x, y, z)
- velocity (x, y, z)
- time
- weight
- polarization (optional) (x, y, z)

In addition there is support for a position and time offset, which are both optional.

The major change is the independent time for each neutron, which is useful as the neutrons are not interacting and thus can be propagated to different times in the simulation. The different times are useful in practice as the energy of the neutron can be deduced from the travel time to the sample, and it is thus common to propagate a number of rays to the sample and record position, velocity, time and weight.

The polarization is optional an optional record, but the components are required. This should be interpreted as the entire polarization record can be omitted, but if it isn't, all components are required.

## Affected Components

- `EXT-NRAYTRACING`

## Logic Changes

To my understanding the only required logic change is the possibility of having independent time for each neutron.

## Writer Changes

To my understanding no changes are required in the writer as a consequence of this update.

- `libopenPMD` (upcoming): https://github.com/ComputationalRadiationPhysics/libopenPMD/...

## Reader Changes

I do not see any required changes to readers.

- `openPMD-validator`: https://github.com/openPMD/openPMD-validator/...
- `openPMD-viewer`: https://github.com/openPMD/openPMD-viewer/...
- `yt`: https://github.com/yt-project/yt/...
- `VisIt`: https://github.com/openPMD/openPMD-visit-plugin
- `libopenPMD` (upcoming): https://github.com/ComputationalRadiationPhysics/libopenPMD/...
- `XDMF` (upcoming): https://github.com/openPMD/openPMD-tools/...

## Data Converter
No work done on data converters, as this is the first version of the neutron raytracing extension.