### PR TITLE
Domex wavefront

### DIFF
--- a/EXT_WAVEFRONT.md
+++ b/EXT_WAVEFRONT.md
@@ -46,7 +46,7 @@ The individual requirement is given in `scope`.
       - `r`: The field is given in cartesian space.
       - `k`: The field is given in reciprocmal space.
 
-  - `R_x`
+  - `R/x`
     - type: *(floatX)*
     - scope: *required*
     - description: Horizontal wavefront curvature radius.
@@ -54,7 +54,7 @@ The individual requirement is given in `scope`.
                               `unitDimension = (1., 0., 0., 0., 0., 0., 0.)`
                               (m)
 
-  - `R_y`
+  - `R/y`
     - type: *(floatX)*
     - scope: *required*
     - description: Vertical wavefront curvature radius.
@@ -62,7 +62,7 @@ The individual requirement is given in `scope`.
                               `unitDimension = (1., 0., 0., 0., 0., 0., 0.)`
                               (m)
 
-  - `Delta R_x`
+  - `Delta_R/x`
     - type: *(floatX)*
     - scope: *required*
     - description: Error in horizontal wavefront curvature radius.
@@ -70,7 +70,7 @@ The individual requirement is given in `scope`.
                               `unitDimension = (1., 0., 0., 0., 0., 0., 0.)`
                               (m)
 
-  - `Delta R_y`
+  - `Delta_R/y`
     - type: *(floatX)*
     - scope: *required*
     - description: Error in vertical wavefront curvature radius.
@@ -85,7 +85,7 @@ When added to an output, the following naming conventions shall be used for
 electric field `mesh records`.
 
 - fundamental fields:
-  - `E_real`
+  - `E_real/x` and `E_real/y`
     - type: *(floatX)* or *(intX)* or *(uintX)*
     - description: the real part of the complex electric field.
     - advice to implementors: a *(floatX)* type is likely the most frequent case
@@ -97,8 +97,8 @@ electric field `mesh records`.
                               `unitDimension = (0., -1,0, 0., 0., 0., 0., 0.)`
                               ((J / eV)^{1/2} / m  = m^{-1})
                               if attribute `Fourier domain` is 'frequency`.
-
-  - `E_imag`
+ 
+ - `E_imag/x` and `E_imag/y`
     - type: *(floatX)* or *(intX)* or *(uintX)*
     - description: the imaginary part of the complex electric field.
     - advice to implementors: a *(floatX)* type is likely the most frequent case

--- a/EXT_WAVEFRONT.md
+++ b/EXT_WAVEFRONT.md
@@ -9,16 +9,12 @@ Introduction
 
 This extension is specifically designed for the domain of coherent wavefront propagation codes.
 
-Additional Group to store constant data (parameters)
-----------------------------------------------------
-
-### Additional Group `params`
-
-The top level Group `params` contains data which is constant for all records.
-The individual requirement is given in `scope`.
+Additional attributes on `series`
+---------------------------------
+On the `series` object, set the following attributes:
 
   - `beamline`
-    - type: array *(string)*
+    - type: *(string)*
     - scope: *optional*
     - description: The string representation of the optical beamline.
 

--- a/EXT_WAVEFRONT.md
+++ b/EXT_WAVEFRONT.md
@@ -104,7 +104,7 @@ electric field `mesh records`.
                               if attribute `Fourier domain` is 'time', or
                               `unitDimension = (0., -1,0, 0., 0., 0., 0., 0.)`
                               ((J / eV)^{1/2} / m  = m^{-1})
-                              if attribute `Fourier domain` is 'frequency`.
+                              if attribute `temporal domain` is 'frequency`.
  
  - `E_imag/x` and `E_imag/y`
     - type: *(floatX)* or *(intX)* or *(uintX)*

--- a/EXT_WAVEFRONT.md
+++ b/EXT_WAVEFRONT.md
@@ -7,15 +7,14 @@ openPMD extension name: `WAVEFRONT`
 Introduction
 ------------
 
-This extension is specifically designed for the domain of electro-dynamic and
-electro-static particle-in-cell (PIC) codes.
+This extension is specifically designed for the domain of coherent wavefront propagation codes.
 
-Mesh Based Records (Fields)
----------------------------
+Additional Group to store constant data (parameters)
+----------------------------------------------------
 
-### Additional Attributes for the Group `meshesPath`
+### Additional Group `params`
 
-The following additional attributes are defined to this extension.
+The top level Group `params` contains data which is constant for all records.
 The individual requirement is given in `scope`.
 
   - `beamline`
@@ -26,7 +25,7 @@ The individual requirement is given in `scope`.
   - `photon energy`
     - type: *(floatX)* or *(intX)* or *(uintX)*
     - description: The central photon energy of the wavefield.
-    - `unitDimension = (1., 0., 0., 0., 0., 0., 0.)` (m)1
+    - `unitDimension = (1., 0., 0., 0., 0., 0., 0.)` (m)
     - `unitSI = 1.602176634e−19`
     - scope: *required*
 
@@ -80,6 +79,9 @@ The individual requirement is given in `scope`.
                               `unitDimension = (1., 0., 0., 0., 0., 0., 0.)`
                               (m)
 
+
+Mesh records
+------------
 
 ### Naming Conventions for `mesh record`s (field records)
 

--- a/EXT_WAVEFRONT.md
+++ b/EXT_WAVEFRONT.md
@@ -1,0 +1,82 @@
+Domain-Specific Naming Conventions for Coherent Wavefront Propagation Codes
+===========================================================================
+
+openPMD extension name: `WAVEFRONT`
+
+
+Introduction
+------------
+
+This extension is specifically designed for the domain of electro-dynamic and
+electro-static particle-in-cell (PIC) codes.
+
+Mesh Based Records (Fields)
+---------------------------
+
+### Additional Attributes for the Group `meshesPath`
+
+The following additional attributes are defined to this extension.
+The individual requirement is given in `scope`.
+
+  - `beamline`
+    - type: array *(string)*
+    - scope: *optional*
+    - description: The list of beamline elements
+
+  - `beamline parameters`
+    - type: array of *(int)* of shape 11 `N`
+    - scope: *required* if `beamline` is present
+TODO: check dimensions
+    - description: The 11 propagation parameters for each of the `N` beamline elements.
+
+### Additional Attributes for each `mesh record` (field record)
+
+The following additional attributes for `mesh record`s are defined in this
+extension. The individual requirement is given in `scope`.
+
+  - `Fourier domain`
+    - type: *(string)*
+    - scope: *required*
+    - description: Indicates whether the data represents a field in time or
+      frequency (energy) domain.
+    - allowed values:
+      - `time`: The field is given for the time domain.
+      - `frequency`: The field is given for the frequency (energy) domain.
+
+### Naming Conventions for `mesh record`s (field records)
+
+When added to an output, the following naming conventions shall be used for
+`mesh records` to allow an easy the identification of essential fields. If
+these namings are not used, tools might still detect a record by it's
+`unitDimension` as, e.g., *an* electric field but not as *the* main electric
+field that should be distributed again on the cells.
+
+- fundamental fields:
+  - `E_real`
+    - type: *(floatX)* or *(intX)* or *(uintX)*
+    - description: the real part of the complex electric field.
+    - advice to implementors: a *(floatX)* type is likely the most frequent case
+                              for this record
+TODO: check unit dimensions
+    - advice to implementors: must have
+                              `unitDimension = (1., 1., -3., -1., 0., 0., 0.)`
+                              (V/m = kg * m / (A * s^3))
+                              if attribute `Fourier domain` is 'time', or
+                              `unitDimension = (1., 1., -3., -1., 0., 0., 0.)`
+                              (V/m = kg * m / (A * s^3))
+                              if attribute `Fourier domain` is 'frequency`.
+
+  - `E_imag`
+    - type: *(floatX)* or *(intX)* or *(uintX)*
+    - description: the imaginary part of the complex electric field.
+    - advice to implementors: must have
+                              `unitDimension = (1., 1., -3., -1., 0., 0., 0.)`
+                              if attribute `Fourier domain` is 'time', or
+                              `unitDimension = (1., 1., -3., -1., 0., 0., 0.)`
+                              (V/m = kg * m / (A * s^3))
+                              if attribute `Fourier domain` is 'frequency`.
+
+   - advice to implementors: a *(floatX)* type is likely the most frequent case
+                              for this record
+
+

--- a/EXT_WAVEFRONT.md
+++ b/EXT_WAVEFRONT.md
@@ -21,20 +21,14 @@ The individual requirement is given in `scope`.
   - `beamline`
     - type: array *(string)*
     - scope: *optional*
-    - description: The list of beamline elements
+    - description: The string representation of the optical beamline.
 
-  - `beamline parameters`
-    - type: array of *(int)* of shape 11 `N`
-    - scope: *required* if `beamline` is present
-TODO: check dimensions
-    - description: The 11 propagation parameters for each of the `N` beamline elements.
+  - `photon energy`
+    - type: *(floatX)* or *(intX)* or *(uintX)*
+    - description: The central photon energy of the wavefield.
+    - scope: *required*
 
-### Additional Attributes for each `mesh record` (field record)
-
-The following additional attributes for `mesh record`s are defined in this
-extension. The individual requirement is given in `scope`.
-
-  - `Fourier domain`
+  - `temporal domain`
     - type: *(string)*
     - scope: *required*
     - description: Indicates whether the data represents a field in time or
@@ -43,13 +37,52 @@ extension. The individual requirement is given in `scope`.
       - `time`: The field is given for the time domain.
       - `frequency`: The field is given for the frequency (energy) domain.
 
+  - `spatial domain`
+    - type: *(string)*
+    - scope: *required*
+    - description: Indicates whether the data represents a field in cartesian
+      (r) or reciprocal (k) space.
+    - allowed values:
+      - `r`: The field is given in cartesian space.
+      - `k`: The field is given in reciprocal space.
+
+  - `R_x`
+    - type: *(floatX)*
+    - scope: *required*
+    - description: Horizontal wavefront curvature radius.
+    - advice to implementors: must have
+                              `unitDimension = (1., 0., 0., 0., 0., 0., 0.)`
+                              (m)
+
+  - `R_y`
+    - type: *(floatX)*
+    - scope: *required*
+    - description: Vertical wavefront curvature radius.
+    - advice to implementors: must have
+                              `unitDimension = (1., 0., 0., 0., 0., 0., 0.)`
+                              (m)
+
+  - `Delta R_x`
+    - type: *(floatX)*
+    - scope: *required*
+    - description: Error in horizontal wavefront curvature radius.
+    - advice to implementors: must have
+                              `unitDimension = (1., 0., 0., 0., 0., 0., 0.)`
+                              (m)
+
+  - `Delta R_y`
+    - type: *(floatX)*
+    - scope: *required*
+    - description: Error in vertical wavefront curvature radius.
+    - advice to implementors: must have
+                              `unitDimension = (1., 0., 0., 0., 0., 0., 0.)`
+                              (m)
+
+
 ### Naming Conventions for `mesh record`s (field records)
 
 When added to an output, the following naming conventions shall be used for
-`mesh records` to allow an easy the identification of essential fields. If
-these namings are not used, tools might still detect a record by it's
-`unitDimension` as, e.g., *an* electric field but not as *the* main electric
-field that should be distributed again on the cells.
+electric field `mesh records`.
 
 - fundamental fields:
   - `E_real`
@@ -57,26 +90,25 @@ field that should be distributed again on the cells.
     - description: the real part of the complex electric field.
     - advice to implementors: a *(floatX)* type is likely the most frequent case
                               for this record
-TODO: check unit dimensions
     - advice to implementors: must have
-                              `unitDimension = (1., 1., -3., -1., 0., 0., 0.)`
-                              (V/m = kg * m / (A * s^3))
+                              `unitDimension = (0., 0.5, -1.5, 0., 0., 0., 0.)`
+                              (W^{1/2} / m = (kg / s^3)^{1/2})
                               if attribute `Fourier domain` is 'time', or
-                              `unitDimension = (1., 1., -3., -1., 0., 0., 0.)`
-                              (V/m = kg * m / (A * s^3))
+                              `unitDimension = (0., -1,0, 0., 0., 0., 0., 0.)`
+                              ((J / eV)^{1/2} / m  = m^{-1})
                               if attribute `Fourier domain` is 'frequency`.
 
   - `E_imag`
     - type: *(floatX)* or *(intX)* or *(uintX)*
     - description: the imaginary part of the complex electric field.
-    - advice to implementors: must have
-                              `unitDimension = (1., 1., -3., -1., 0., 0., 0.)`
-                              if attribute `Fourier domain` is 'time', or
-                              `unitDimension = (1., 1., -3., -1., 0., 0., 0.)`
-                              (V/m = kg * m / (A * s^3))
-                              if attribute `Fourier domain` is 'frequency`.
-
-   - advice to implementors: a *(floatX)* type is likely the most frequent case
+    - advice to implementors: a *(floatX)* type is likely the most frequent case
                               for this record
+    - advice to implementors: must have
+                              `unitDimension = (0., 0.5, -1.5, 0., 0., 0., 0.)`
+                              (W^{1/2} / m = (kg / s^3)^{1/2})
+                              if attribute `Fourier domain` is 'time', or
+                              `unitDimension = (0., -1,0, 0., 0., 0., 0., 0.)`
+                              ((J / eV)^{1/2} / m  = m^{-1})
+                              if attribute `Fourier domain` is 'frequency`.
 
 

--- a/EXT_WAVEFRONT.md
+++ b/EXT_WAVEFRONT.md
@@ -44,7 +44,7 @@ The individual requirement is given in `scope`.
       (r) or reciprocal (k) space.
     - allowed values:
       - `r`: The field is given in cartesian space.
-      - `k`: The field is given in reciprocal space.
+      - `k`: The field is given in reciprocmal space.
 
   - `R_x`
     - type: *(floatX)*

--- a/EXT_WAVEFRONT.md
+++ b/EXT_WAVEFRONT.md
@@ -117,6 +117,6 @@ electric field `mesh records`.
                               if attribute `Fourier domain` is 'time', or
                               `unitDimension = (0., -1,0, 0., 0., 0., 0., 0.)`
                               ((J / eV)^{1/2} / m  = m^{-1})
-                              if attribute `Fourier domain` is 'frequency`.
+                              if attribute `temporal domain` is 'frequency`.
 
 

--- a/EXT_WAVEFRONT.md
+++ b/EXT_WAVEFRONT.md
@@ -26,6 +26,8 @@ The individual requirement is given in `scope`.
   - `photon energy`
     - type: *(floatX)* or *(intX)* or *(uintX)*
     - description: The central photon energy of the wavefield.
+    - `unitDimension = (1., 0., 0., 0., 0., 0., 0.)` (m)1
+    - `unitSI = 1.602176634e−19`
     - scope: *required*
 
   - `temporal domain`

--- a/EXT_WAVEFRONT.md
+++ b/EXT_WAVEFRONT.md
@@ -18,13 +18,6 @@ On the `series` object, set the following attributes:
     - scope: *optional*
     - description: The string representation of the optical beamline.
 
-  - `photon energy`
-    - type: *(floatX)* or *(intX)* or *(uintX)*
-    - description: The central photon energy of the wavefield.
-    - `unitDimension = (1., 0., 0., 0., 0., 0., 0.)` (m)
-    - `unitSI = 1.602176634e−19`
-    - scope: *required*
-
   - `temporal domain`
     - type: *(string)*
     - scope: *required*
@@ -43,7 +36,22 @@ On the `series` object, set the following attributes:
       - `r`: The field is given in cartesian space.
       - `k`: The field is given in reciprocmal space.
 
-  - `R/x`
+Additional records
+------------------
+- `z coordinate`
+    -type: *(floatX)*
+    -description: The z coordinate with respect to the beamline origin.
+    - `unitDimension = (1., 0., 0., 0., 0., 0., 0.)` (m)
+    - scope: *required*
+
+- `photon energy`
+    - type: *(floatX)* or *(intX)* or *(uintX)*
+    - description: The central photon energy of the wavefield.
+    - `unitDimension = (1., 2., -2., 0., 0., 0., 0.)` (J = kg m^2/s^2)
+    - `unitSI = 1.602176634e−19`
+    - scope: *required*
+
+- `R/x`
     - type: *(floatX)*
     - scope: *required*
     - description: Horizontal wavefront curvature radius.
@@ -51,7 +59,7 @@ On the `series` object, set the following attributes:
                               `unitDimension = (1., 0., 0., 0., 0., 0., 0.)`
                               (m)
 
-  - `R/y`
+- `R/y`
     - type: *(floatX)*
     - scope: *required*
     - description: Vertical wavefront curvature radius.
@@ -59,7 +67,7 @@ On the `series` object, set the following attributes:
                               `unitDimension = (1., 0., 0., 0., 0., 0., 0.)`
                               (m)
 
-  - `Delta_R/x`
+- `Delta_R/x`
     - type: *(floatX)*
     - scope: *required*
     - description: Error in horizontal wavefront curvature radius.
@@ -67,7 +75,7 @@ On the `series` object, set the following attributes:
                               `unitDimension = (1., 0., 0., 0., 0., 0., 0.)`
                               (m)
 
-  - `Delta_R/y`
+- `Delta_R/y`
     - type: *(floatX)*
     - scope: *required*
     - description: Error in vertical wavefront curvature radius.


### PR DESCRIPTION
This PR implements a [domain extension for coherent wavefront propagation](https://github.com/PaNOSC-ViNYL/ViNYL-project/issues/16)
*Implements issue:* https://github.com/PaNOSC-ViNYL/ViNYL-project/issues/16

# Will add this information later.

## Description

*What is introduced, removed or renamed and why?*
*What is made required, recommended, optional?*
*What concept stands behind this change?*

*Please also add an example.*

## Affected Components

- `base`
- `EXT-...`

## Logic Changes

*Which logic changes are conceptually introduced?*

## Writer Changes

*How does this change affect data writers?*
*What would a writer need to change?*
*Does this pull request change the interpretation of existing data writers?*

- `libopenPMD` (upcoming): https://github.com/ComputationalRadiationPhysics/libopenPMD/...

## Reader Changes

*How does this change affect data readers?*

*What would a reader need to change? Link implementation examples!*

- `openPMD-validator`: https://github.com/openPMD/openPMD-validator/...
- `openPMD-viewer`: https://github.com/openPMD/openPMD-viewer/...
- `yt`: https://github.com/yt-project/yt/...
- `VisIt`: https://github.com/openPMD/openPMD-visit-plugin
- `libopenPMD` (upcoming): https://github.com/ComputationalRadiationPhysics/libopenPMD/...
- `XDMF` (upcoming): https://github.com/openPMD/openPMD-tools/...

## Data Converter

*How does this affect already existing files with previous versions of the standard?*
*Is this change possible to be expressed in a way, that an automated tool can update the file?*
*Link code/pull requests that implement the upgrade logic!*

- https://github.com/openPMD/openPMD-converter/...
