### PR TITLE
Upcoming 2.0.0

### DIFF
--- a/EXT_WAVEFRONT.md
+++ b/EXT_WAVEFRONT.md
@@ -29,9 +29,9 @@ electric field `mesh records`.
   - decription: electric field representing the wavefront. The field oscillate as $\exp(-i \omega t)$, where $\omega = 2\pi$*`frequency`. The real field at a time $t$ is then $\Re($`electricField` * $\exp(-i \omega t)$
   
   - advice to implementors: if attribute `temporal domain` is `'time'`, this is an electric field with SI unit in `V/m`, and therefore must have:
-    - `unitDimension = (1, 1, -3, -1, 0, 0, 0)`  (V/m)
+    - `unitDimension = (1, 1, -3, -1, 0, 0, 0)`  (electric field)
   - advice to implementors: if attribute `temporal domain` is `'frequency'`, this must have:
-    - `unitDimension = (0. -1, 0, 0, 0, 0, 0)` ($\sqrt{\textrm{J} / \textrm{eV} }/ \textrm{m}  = \textrm{m}^{-1}$)
+    - `unitDimension = (0. -1, 0, 0, 0, 0, 0)` (per meter, as $\sqrt{\textrm{J} / \textrm{eV} }/ \textrm{m}  = \textrm{m}^{-1}$)
 
 
 ### Additional attributes on `mesh record`s (field records)
@@ -42,14 +42,14 @@ On the `series` object, set the following attributes:
     - type: *(floatX)* or *(intX)* or *(uintX)*
     - description: central frequency $f$, related to the angular frequency $\omega=2\pi f$.
     - scope: *required*
-    - `unitDimension = (0., 0., -1., 0., 0., 0., 0.)` (Hz)
+    - `unitDimension = (0., 0., -1., 0., 0., 0., 0.)` (cycle per second)
 
 
   - `photonEnergy`
     - type: *(floatX)* or *(intX)* or *(uintX)*
     - description: The central photon energy of the wavefield $E_\textrm{photon} = h$*`frequency`, where $h$ is Planck's constant.
     - scope: *optional*
-    - `unitDimension = (2., 1., -2., 0., 0., 0., 0.)` (J)
+    - `unitDimension = (2., 1., -2., 0., 0., 0., 0.)` (energy)
 
 
   - `temporalDomain`
@@ -75,7 +75,7 @@ On the `series` object, set the following attributes:
   - `zCoordinate`
     - type: *(floatX)*
     - description: The z coordinate with respect to the beamline origin.
-    - `unitDimension = (1., 0., 0., 0., 0., 0., 0.)` (m)
+    - `unitDimension = (1., 0., 0., 0., 0., 0., 0.)` (length)
     - scope: *required*      
 
 
@@ -89,28 +89,28 @@ On the `series` object, set the following attributes:
     - type: *(floatX)*
     - scope: *optional*
     - description: Horizontal wavefront curvature radius.
-    - `unitDimension = (1., 0., 0., 0., 0., 0., 0.)` (m)
+    - `unitDimension = (1., 0., 0., 0., 0., 0., 0.)` (length)
 
 
   - `radiusOfCurvatureY`
     - type: *(floatX)*
     - scope: *optional*
     - description: Vertical wavefront curvature radius.
-    - `unitDimension = (1., 0., 0., 0., 0., 0., 0.)` (m)
+    - `unitDimension = (1., 0., 0., 0., 0., 0., 0.)` (length)
 
 
   - `deltaRadiusOfCurvatureX`
     - type: *(floatX)*
     - scope:*optional*
     - description: Error in horizontal wavefront curvature radius.
-    - `unitDimension = (1., 0., 0., 0., 0., 0., 0.)` (m)
+    - `unitDimension = (1., 0., 0., 0., 0., 0., 0.)` (length)
 
 
   - `deltaRadiusOfCurvatureY`
     - type: *(floatX)*
     - scope: *optional*
     - description: Error in vertical wavefront curvature radius.
-    - `unitDimension = (1., 0., 0., 0., 0., 0., 0.)` (m)
+    - `unitDimension = (1., 0., 0., 0., 0., 0., 0.)` (length)
 
 
 

--- a/EXT_WAVEFRONT.md
+++ b/EXT_WAVEFRONT.md
@@ -29,6 +29,8 @@ electric field `mesh records`.
     - `z/`     
   - decription: electric field representing the wavefront. The field oscillate as $\exp(-i \omega t)$, where $\omega = 2\pi$*`frequency`. The real field at a time $t$ is then $\Re($`electricField` * $\exp(-i \omega t)$
   
+   - <img src="https://render.githubusercontent.com/render/math?math=e^{i \pi} = -1">
+  
   - advice to implementors: if attribute `temporal domain` is `'time'`, this is an electric field with SI unit in `V/m`, and therefore must have:
     - `unitDimension = (1, 1, -3, -1, 0, 0, 0)`  (electric field)
   - advice to implementors: if attribute `temporal domain` is `'frequency'`, this must have:

--- a/EXT_WAVEFRONT.md
+++ b/EXT_WAVEFRONT.md
@@ -27,9 +27,8 @@ electric field `mesh records`.
     - `x/` 
     - `y/` 
     - `z/`     
-  - decription: electric field representing the wavefront. The field oscillate as $\exp(-i \omega t)$, where $\omega = 2\pi$*`frequency`. The real field at a time $t$ is then $\Re($`electricField` * $\exp(-i \omega t)$
+  - decription: electric field representing the wavefront. The field oscillate as $\exp(-i \omega t)$, where $\omega = 2\pi$*`frequency`. The real field at a time $t$ is then $\Re($`electricField` * <img src="https://render.githubusercontent.com/render/math?math=\exp(-i \omega t)">
   
-   - <img src="https://render.githubusercontent.com/render/math?math=e^{i \pi} = -1">
   
   - advice to implementors: if attribute `temporal domain` is `'time'`, this is an electric field with SI unit in `V/m`, and therefore must have:
     - `unitDimension = (1, 1, -3, -1, 0, 0, 0)`  (electric field)

--- a/EXT_WAVEFRONT.md
+++ b/EXT_WAVEFRONT.md
@@ -26,12 +26,13 @@ electric field `mesh records`.
   - components:
     - `x/` 
     - `y/` 
+    - `z/`     
   - decription: electric field representing the wavefront. The field oscillate as $\exp(-i \omega t)$, where $\omega = 2\pi$*`frequency`. The real field at a time $t$ is then $\Re($`electricField` * $\exp(-i \omega t)$
   
   - advice to implementors: if attribute `temporal domain` is `'time'`, this is an electric field with SI unit in `V/m`, and therefore must have:
     - `unitDimension = (1, 1, -3, -1, 0, 0, 0)`  (electric field)
   - advice to implementors: if attribute `temporal domain` is `'frequency'`, this must have:
-    - `unitDimension = (0. -1, 0, 0, 0, 0, 0)` (per meter, as $\sqrt{\textrm{J} / \textrm{eV} }/ \textrm{m}  = \textrm{m}^{-1}$)
+    - `unitDimension = (0. -1, 0, 0, 0, 0, 0)` (inverse length, as $\sqrt{\textrm{J} / \textrm{eV} }/ \textrm{m}  = \textrm{m}^{-1}$)
 
 
 ### Additional attributes on `mesh record`s (field records)

--- a/EXT_WAVEFRONT.md
+++ b/EXT_WAVEFRONT.md
@@ -35,7 +35,7 @@ electric field `mesh records`.
     - `unitDimension = (0. -1, 0, 0, 0, 0, 0)` (inverse length, as $\sqrt{\textrm{J} / \textrm{eV} }/ \textrm{m}  = \textrm{m}^{-1}$)
 
 
-### Additional attributes on `mesh record`s (field records)
+### Additional attributes on the `mesh record` named `electricField`
 
 On the `series` object, set the following attributes:
 
@@ -105,7 +105,6 @@ On the `series` object, set the following attributes:
     - scope: *optional*
     - description: Error in vertical wavefront curvature radius.
     - `unitDimension = (1., 0., 0., 0., 0., 0., 0.)` (length)
-
 
 
 

--- a/EXT_WAVEFRONT.md
+++ b/EXT_WAVEFRONT.md
@@ -27,8 +27,7 @@ electric field `mesh records`.
     - `x/` 
     - `y/` 
     - `z/`     
-  - decription: electric field representing the wavefront. The field oscillate as $\exp(-i \omega t)$, where $\omega = 2\pi$*`frequency`. The real field at a time $t$ is then $\Re($`electricField` * <img src="https://render.githubusercontent.com/render/math?math=\exp(-i \omega t)">
-  
+  - decription: electric field representing the wavefront. The field oscillate as $\exp(-i \omega t)$, where $\omega = 2\pi$*`frequency`. The real field at a time $t$ is then $\Re($ `electricField` * $\exp(-i \omega t)$
   
   - advice to implementors: if attribute `temporal domain` is `'time'`, this is an electric field with SI unit in `V/m`, and therefore must have:
     - `unitDimension = (1, 1, -3, -1, 0, 0, 0)`  (electric field)

--- a/EXT_WAVEFRONT.md
+++ b/EXT_WAVEFRONT.md
@@ -27,7 +27,7 @@ electric field `mesh records`.
     - `x/` 
     - `y/` 
     - `z/`     
-  - decription: electric field representing the wavefront. The field oscillate as $\exp(-i \omega t)$, where $\omega = 2\pi$*`frequency`. The real field at a time $t$ is then $\Re($ `electricField` * $\exp(-i \omega t)$
+  - decription: electric field representing the wavefront. The field oscillate as $\exp(-i \omega t)$, where the angular frequency $\omega$ is related to `photonEnergy` defined below. The real field at a time $t$ is then $\Re($ `electricField` * $\exp(-i \omega t)$)
   
   - advice to implementors: if attribute `temporal domain` is `'time'`, this is an electric field with SI unit in `V/m`, and therefore must have:
     - `unitDimension = (1, 1, -3, -1, 0, 0, 0)`  (electric field)
@@ -39,17 +39,10 @@ electric field `mesh records`.
 
 On the `series` object, set the following attributes:
 
-  - `frequency`
-    - type: *(floatX)* or *(intX)* or *(uintX)*
-    - description: central frequency $f$, related to the angular frequency $\omega=2\pi f$.
-    - scope: *required*
-    - `unitDimension = (0., 0., -1., 0., 0., 0., 0.)` (cycle per second)
-
-
   - `photonEnergy`
-    - type: *(floatX)* or *(intX)* or *(uintX)*
-    - description: The central photon energy of the wavefield $E_\textrm{photon} = h$*`frequency`, where $h$ is Planck's constant.
-    - scope: *optional*
+    - type: *(floatX)* 
+    - description: The central photon energy of the wavefield $E_\textrm{photon} = \hbar \omega $, where $\hbar$ is Planck's constant divided by $2\pi$.
+    - scope: *required*
     - `unitDimension = (2., 1., -2., 0., 0., 0., 0.)` (energy)
 
 

--- a/EXT_WAVEFRONT.md
+++ b/EXT_WAVEFRONT.md
@@ -9,16 +9,50 @@ Introduction
 
 This extension is specifically designed for the domain of coherent wavefront propagation codes.
 
-Additional attributes on `series`
----------------------------------
+
+
+Mesh Based Records (Fields)
+---------------------------
+
+### Naming Conventions for `mesh record`s (field records)
+
+When added to an output, the following naming conventions shall be used for complex
+electric field `mesh records`. 
+
+
+- `electricField/` 
+  - type: *(complexX)*
+  - scope: *(required)*  
+  - components:
+    - `x/` 
+    - `y/` 
+  - decription: electric field representing the wavefront. The field oscillate as $\exp(-i \omega t)$, where $\omega = 2\pi$*`frequency`. The real field at a time $t$ is then $\Re($`electricField` * $\exp(-i \omega t)$
+  
+  - advice to implementors: if attribute `temporal domain` is `'time'`, this is an electric field with SI unit in `V/m`, and therefore must have:
+    - `unitDimension = (1, 1, -3, -1, 0, 0, 0)`  (V/m)
+  - advice to implementors: if attribute `temporal domain` is `'frequency'`, this must have:
+    - `unitDimension = (0. -1, 0, 0, 0, 0, 0)` ($\sqrt{\textrm{J} / \textrm{eV} }/ \textrm{m}  = \textrm{m}^{-1}$)
+
+
+### Additional attributes on `mesh record`s (field records)
+
 On the `series` object, set the following attributes:
 
-  - `beamline`
-    - type: *(string)*
-    - scope: *optional*
-    - description: The string representation of the optical beamline.
+  - `frequency`
+    - type: *(floatX)* or *(intX)* or *(uintX)*
+    - description: central frequency $f$, related to the angular frequency $\omega=2\pi f$.
+    - scope: *required*
+    - `unitDimension = (0., 0., -1., 0., 0., 0., 0.)` (Hz)
 
-  - `temporal domain`
+
+  - `photonEnergy`
+    - type: *(floatX)* or *(intX)* or *(uintX)*
+    - description: The central photon energy of the wavefield $E_\textrm{photon} = h$*`frequency`, where $h$ is Planck's constant.
+    - scope: *optional*
+    - `unitDimension = (2., 1., -2., 0., 0., 0., 0.)` (J)
+
+
+  - `temporalDomain`
     - type: *(string)*
     - scope: *required*
     - description: Indicates whether the data represents a field in time or
@@ -27,7 +61,8 @@ On the `series` object, set the following attributes:
       - `time`: The field is given for the time domain.
       - `frequency`: The field is given for the frequency (energy) domain.
       
-  - `spatial domain`
+      
+  - `spatialDomain`
     - type: *(string)*
     - scope: *required*
     - description: Indicates whether the data represents a field in cartesian
@@ -36,76 +71,47 @@ On the `series` object, set the following attributes:
       - `r`: The field is given in cartesian space.
       - `k`: The field is given in reciprocmal space.
       
-  - `z coordinate`
-    -type: *(floatX)*
-    -description: The z coordinate with respect to the beamline origin.
-    - `unitDimension = (1., 0., 0., 0., 0., 0., 0.)` (m)
-    - scope: *required*
-
-  - `photon energy`
-    - type: *(floatX)* or *(intX)* or *(uintX)*
-    - description: The central photon energy of the wavefield.
-    - scope: *required*
-    - Unit: If not otherwise specified, units of eV are assumed.
-
-  - `radius of curvature in x`
-    - type: *(floatX)*
-    - scope: *required*
-    - description: Horizontal wavefront curvature radius in.
-    - Unit: If not otherwise specified, units of meter are assumed.
-
-  - `radius of curvature in y`
-    - type: *(floatX)*
-    - scope: *required*
-    - description: Vertical wavefront curvature radius.
-    - Unit: If not otherwise specified, units of meter are assumed.
-
-  - `Delta radius of curvature in x`
-    - type: *(floatX)*
-    - scope: *required*
-    - description: Error in horizontal wavefront curvature radius.
-    - Unit: If not otherwise specified, units of meter are assumed.
-
-  - `Delta radius of curvature in y`
-    - type: *(floatX)*
-    - scope: *required*
-    - description: Error in vertical wavefront curvature radius.
-    - Unit: If not otherwise specified, units of meter are assumed.
-
-
-Mesh records
-------------
-
-### Naming Conventions for `mesh record`s (field records)
-
-When added to an output, the following naming conventions shall be used for
-electric field `mesh records`.
-
-- fundamental fields:
-  - `E_real/x` and `E_real/y`
-    - type: *(floatX)* or *(intX)* or *(uintX)*
-    - description: the real part of the complex electric field.
-    - advice to implementors: a *(floatX)* type is likely the most frequent case
-                              for this record
-    - advice to implementors: must have
-                              `unitDimension = (0., 0.5, -1.5, 0., 0., 0., 0.)`
-                              (W^{1/2} / m = (kg / s^3)^{1/2})
-                              if attribute `temporal domain` is 'time', or
-                              `unitDimension = (0., -1,0, 0., 0., 0., 0., 0.)`
-                              ((J / eV)^{1/2} / m  = m^{-1})
-                              if attribute `temporal domain` is 'frequency`.
  
- - `E_imag/x` and `E_imag/y`
-    - type: *(floatX)* or *(intX)* or *(uintX)*
-    - description: the imaginary part of the complex electric field.
-    - advice to implementors: a *(floatX)* type is likely the most frequent case
-                              for this record
-    - advice to implementors: must have
-                              `unitDimension = (0., 0.5, -1.5, 0., 0., 0., 0.)`
-                              (W^{1/2} / m = (kg / s^3)^{1/2})
-                              if attribute `temporal domain` is 'time', or
-                              `unitDimension = (0., -1,0, 0., 0., 0., 0., 0.)`
-                              ((J / eV)^{1/2} / m  = m^{-1})
-                              if attribute `temporal domain` is 'frequency`.
+  - `zCoordinate`
+    - type: *(floatX)*
+    - description: The z coordinate with respect to the beamline origin.
+    - `unitDimension = (1., 0., 0., 0., 0., 0., 0.)` (m)
+    - scope: *required*      
+
+
+  - `beamline`
+    - type: *(string)*
+    - scope: *optional*
+    - description: The string representation of the optical beamline.
+
+
+  - `radiusOfCurvatureX`
+    - type: *(floatX)*
+    - scope: *optional*
+    - description: Horizontal wavefront curvature radius.
+    - `unitDimension = (1., 0., 0., 0., 0., 0., 0.)` (m)
+
+
+  - `radiusOfCurvatureY`
+    - type: *(floatX)*
+    - scope: *optional*
+    - description: Vertical wavefront curvature radius.
+    - `unitDimension = (1., 0., 0., 0., 0., 0., 0.)` (m)
+
+
+  - `deltaRadiusOfCurvatureX`
+    - type: *(floatX)*
+    - scope:*optional*
+    - description: Error in horizontal wavefront curvature radius.
+    - `unitDimension = (1., 0., 0., 0., 0., 0., 0.)` (m)
+
+
+  - `deltaRadiusOfCurvatureY`
+    - type: *(floatX)*
+    - scope: *optional*
+    - description: Error in vertical wavefront curvature radius.
+    - `unitDimension = (1., 0., 0., 0., 0., 0., 0.)` (m)
+
+
 
 


### PR DESCRIPTION
Rework of the openPMD-wavefront extension to be consistent with other extensions and to be more general.

## Description

*What is introduced, removed or renamed and why?*
E_real, E_imag -> electricField (complex) mesh

The units for the electric field in the time domain must be `V/m`. 

All attributes names are changed to snakeCase to be consistent with the base standard.

*What is made required, recommended, optional?*
photonEnergy attribute is required, other information ones are now optional

*What concept stands behind this change?*
Better generality, and usability with SRW, Genesis 1.3

## Affected Components

- `EXT-WAVEFRONT`

## Logic Changes

None (?)

## Writer Changes

Writers will need to read complex datasets

## Reader Changes

Readers will need to read complex datasets

## Data Converter

Previous files will need to be upgraded. 
